### PR TITLE
Rename .marketplace-kit to .pos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.0
+* 💥 BREAKING 💥 Removed `--config-file` option from all commands. `CONFIG_FILE_PATH` environment variable is working as previously.
+* Renamed `.marketplace-kit` file to `.pos`. To not break existing processes, `pos-cli` is looking for `.marketplace-kit` as well. This fallback will be removed in the next major version release.
+
 ## 3.0.8 July 16, 2019
 * Improved messaging when using `--direct-assets-upload` in `pos-cli deploy`.
 * Improved help message when command is not found or argument is missing.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pos-cli env add <environment> --email <your email> --url <your application url>
 
 Example: `pos-cli env add staging --email myemail@example.com --url https://example.com`
 
-Configuration for environments lays down in `.marketplace-kit` file.
+Configuration for environments lays down in `.pos` file.
 
 ### Syncing changes
 
@@ -140,7 +140,7 @@ Lists migrations deployed to the server and their current status.
 pos-cli migrations list <environment> <name>
 ```
 
-#### Generate 
+#### Generate
 
 Generates new migration with the name you provided. It will be prepended with a timestamp so if you create more than one, they will be run in the order you intended.
 
@@ -175,7 +175,7 @@ Exports data from the environment to a given file in form of JSON.
 Read more about exporting data with CLI, REST API and GraphQL [in our documentation](https://documentation.platformos.com/tutorials/data-import-export/export).
 
 ```
-pos-cli data export staging --path=data.json 
+pos-cli data export staging --path=data.json
 ```
 
 #### Import
@@ -186,7 +186,7 @@ Read more about importing data with CLI, REST API and GraphQL [in our documentat
 
 
 ```
-pos-cli data import staging --path=data.json 
+pos-cli data import staging --path=data.json
 ```
 
 #### Clean (only staging)

--- a/bin/pos-cli-data-clean.js
+++ b/bin/pos-cli-data-clean.js
@@ -33,7 +33,6 @@ const confirmCleanup = async (gateway, inlineConfirmation) => {
     clean(gateway);
   } else {
     logger.Error('Wrong confirmation. Closed without cleaning instance data.');
-    process.exit(1);
   }
 };
 
@@ -41,9 +40,7 @@ program
   .name('pos-cli data clean')
   .arguments('[environment]', 'name of the environment. Example: staging')
   .option('--auto-confirm', 'auto confirm instance clean without prompt')
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
   .action((environment, params) => {
-    process.env.CONFIG_FILE_PATH = params.configFile;
     const gateway = new Gateway(fetchAuthData(environment, program));
 
     confirmCleanup(gateway, params.autoConfirm);

--- a/bin/pos-cli-data-export.js
+++ b/bin/pos-cli-data-export.js
@@ -42,9 +42,7 @@ program
     'use normal object `id` instead of `external_id` in exported json data',
     'false'
   )
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
   .action((environment, params) => {
-    process.env.CONFIG_FILE_PATH = params.configFile;
     const filename = params.path;
     const exportInternalIds = params.exportInternalIds;
     const authData = fetchAuthData(environment, program);

--- a/bin/pos-cli-data-import.js
+++ b/bin/pos-cli-data-import.js
@@ -60,9 +60,7 @@ program
   .name('pos-cli data import')
   .arguments('[environment]', 'name of the environment. Example: staging')
   .option('-p --path <import-file-path>', 'path of import .json file', 'data.json')
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
   .action((environment, params) => {
-    process.env.CONFIG_FILE_PATH = params.configFile;
     const filename = params.path;
     const authData = fetchAuthData(environment, program);
     Object.assign(process.env, {

--- a/bin/pos-cli-data-update.js
+++ b/bin/pos-cli-data-update.js
@@ -16,9 +16,7 @@ program
   .name('pos-cli data update')
   .arguments('[environment]', 'name of the environment. Example: staging')
   .option('-p --path <update-file-path>', 'path of update .json file', 'data.json')
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
   .action((environment, params) => {
-    process.env.CONFIG_FILE_PATH = params.configFile;
     const filename = params.path;
     const authData = fetchAuthData(environment, program);
     Object.assign(process.env, {

--- a/bin/pos-cli-deploy.js
+++ b/bin/pos-cli-deploy.js
@@ -22,10 +22,7 @@ program
   .option('-f --force', 'deprecated')
   .option('-d --direct-assets-upload', 'Uploads assets straight to S3 servers. [experimental]')
   .option('-p --partial-deploy', 'Partial deployment, does not remove data from directories missing from the build')
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
   .action(async (environment, params) => {
-    process.env.CONFIG_FILE_PATH = params.configFile;
-
     const strategy = params.directAssetsUpload ? 'directAssetsUpload' : 'default';
 
     if (params.force) {

--- a/bin/pos-cli-env-list.js
+++ b/bin/pos-cli-env-list.js
@@ -1,19 +1,14 @@
 #!/usr/bin/env node
 
-const program = require('commander'),
+const program = require('commander');
+
+const list = require('../lib/settings').listEnvironments(),
   logger = require('../lib/logger');
 
-program
-  .name('pos-cli env list')
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
-  .parse(process.argv);
-
-process.env.CONFIG_FILE_PATH = program.configFile;
-
-const list = require('../lib/settings').listEnvironments();
+program.name('pos-cli env list').parse(process.argv);
 
 logger.Info('Available environments: ');
 
 for (const id in list) {
-  logger.Info(`- ${list[id]}`);
+  logger.Info(`- ${list[id]}`, { hideTimestamp: true });
 }

--- a/bin/pos-cli-env.js
+++ b/bin/pos-cli-env.js
@@ -10,7 +10,3 @@ program
   )
   .command('list', 'list all environments')
   .parse(process.argv);
-
-if (!program.args.length) {
-  program.help();
-}

--- a/bin/pos-cli-gui-serve.js
+++ b/bin/pos-cli-gui-serve.js
@@ -9,10 +9,8 @@ const program = require('commander'),
 program
   .name('pos-cli gui serve')
   .arguments('[environment]', 'name of environment. Example: staging')
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
   .option('-p --port <port>', 'use PORT', '3333')
   .action((environment, params) => {
-    process.env.CONFIG_FILE_PATH = params.configFile;
     const authData = fetchAuthData(environment, program);
 
     Object.assign(process.env, {

--- a/bin/pos-cli-gui.js
+++ b/bin/pos-cli-gui.js
@@ -6,7 +6,3 @@ program
   .name('pos-cli gui')
   .command('serve [environment]', 'serve admin editor for files from given environment')
   .parse(process.argv);
-
-if (!program.args.length) {
-  program.help();
-}

--- a/bin/pos-cli-logs.js
+++ b/bin/pos-cli-logs.js
@@ -49,10 +49,8 @@ const isError = msg => msg.error_type.match(/error/gi);
 program
   .name('pos-cli logs')
   .arguments('[environment]', 'name of environment. Example: staging')
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
   .option('--interval <interval>', 'time to wait between updates in ms', 3000)
-  .action((environment, params) => {
-    process.env.CONFIG_FILE_PATH = params.configFile;
+  .action(environment => {
     process.env.INTERVAL = program.interval;
 
     const authData = fetchAuthData(environment, program);

--- a/bin/pos-cli-migrations-generate.js
+++ b/bin/pos-cli-migrations-generate.js
@@ -12,9 +12,7 @@ program
   .name('pos-cli migrations generate')
   .arguments('[environment]', 'name of the environment. Example: staging')
   .arguments('<name>', 'base name of the migration. Example: cleanup_data')
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
-  .action((environment, name, params) => {
-    process.env.CONFIG_FILE_PATH = params.configFile;
+  .action((environment, name) => {
     const authData = fetchAuthData(environment, program);
     const gateway = new Gateway(authData);
     const formData = { name: name };

--- a/bin/pos-cli-migrations-list.js
+++ b/bin/pos-cli-migrations-list.js
@@ -13,9 +13,7 @@ const logMigration = migration => {
 program
   .name('pos-cli migrations list')
   .arguments('[environment]', 'name of the environment. Example: staging')
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
-  .action((environment, params) => {
-    process.env.CONFIG_FILE_PATH = params.configFile;
+  .action(environment => {
     const authData = fetchAuthData(environment, program);
     const gateway = new Gateway(authData);
 

--- a/bin/pos-cli-migrations-run.js
+++ b/bin/pos-cli-migrations-run.js
@@ -9,9 +9,7 @@ program
   .name('pos-cli migrations run')
   .arguments('[environment]', 'name of the environment. Example: staging')
   .arguments('<timestamp>', 'timestamp the migration. Example: 20180701182602')
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
-  .action((environment, timestamp, params) => {
-    process.env.CONFIG_FILE_PATH = params.configFile;
+  .action((environment, timestamp) => {
     const authData = fetchAuthData(environment, program);
     const gateway = new Gateway(authData);
     const formData = { timestamp: timestamp };

--- a/bin/pos-cli-modules-list.js
+++ b/bin/pos-cli-modules-list.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-const program = require('commander'),
+const program = require('commander');
+
+const files = require('../lib/files'),
   Gateway = require('../lib/proxy'),
   logger = require('../lib/logger'),
   fetchAuthData = require('../lib/settings').fetchSettings;
@@ -8,9 +10,7 @@ const program = require('commander'),
 program
   .name('pos-cli modules list')
   .arguments('[environment]', 'name of the environment. Example: staging')
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
-  .action((environment, params) => {
-    process.env.CONFIG_FILE_PATH = params.configFile;
+  .action(environment => {
     const authData = fetchAuthData(environment, program);
     const gateway = new Gateway(authData);
 

--- a/bin/pos-cli-modules-remove.js
+++ b/bin/pos-cli-modules-remove.js
@@ -3,13 +3,14 @@
 const program = require('commander'),
   Gateway = require('../lib/proxy'),
   logger = require('../lib/logger'),
+  files = require('../lib/files');
   fetchAuthData = require('../lib/settings').fetchSettings;
 
 program
   .name('pos-cli modules remove')
   .arguments('[environment]', 'name of the environment. Example: staging')
   .arguments('<name>', 'name of the module. Example: admin_cms')
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
+  .option('-c --config-file <config-file>', 'config file path', files.CONFIG)
   .action((environment, name, params) => {
     process.env.CONFIG_FILE_PATH = params.configFile;
     const authData = fetchAuthData(environment, program);

--- a/bin/pos-cli-pull.js
+++ b/bin/pos-cli-pull.js
@@ -6,12 +6,13 @@ const program = require('commander'),
   fetchAuthData = require('../lib/settings').fetchSettings,
   yaml = require('js-yaml'),
   dir = require('../lib/directories'),
+  files = require('../lib/files'),
   Gateway = require('../lib/proxy');
 
 program
   .name('pos-cli pull')
   .arguments('[environment]', 'Name of environment. Example: staging')
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
+  .option('-c --config-file <config-file>', 'config file path', files.CONFIG)
   .option('-t --type <type>', 'item type - LiquidView', 'Page')
   .action((environment, params) => {
     process.env.CONFIG_FILE_PATH = params.configFile;

--- a/bin/pos-cli-sync.js
+++ b/bin/pos-cli-sync.js
@@ -4,14 +4,15 @@ const program = require('commander'),
   spawn = require('child_process').spawn,
   command = require('../lib/command'),
   fetchAuthData = require('../lib/settings').fetchSettings,
-  logger = require('../lib/logger');
+  logger = require('../lib/logger'),
+  files = require('../lib/files');
 
 const DEFAULT_CONCURRENCY = 3;
 
 program
   .name('pos-cli sync')
   .arguments('[environment]', 'Name of environment. Example: staging')
-  .option('-c --config-file <config-file>', 'config file path', '.marketplace-kit')
+  .option('-c --config-file <config-file>', 'config file path', files.CONFIG)
   .option('--concurrency <number>', 'maximum concurrent connections to the server', DEFAULT_CONCURRENCY)
   .action((environment, params) => {
     process.env.CONFIG_FILE_PATH = params.configFile;

--- a/lib/data/isValidJSON.js
+++ b/lib/data/isValidJSON.js
@@ -1,3 +1,4 @@
+// TODO: Move to validators...
 const isValidJSON = data => {
   try {
     JSON.parse(data);

--- a/lib/files.js
+++ b/lib/files.js
@@ -1,0 +1,41 @@
+const path = require('path');
+const fs = require('fs');
+
+const logger = require('./logger');
+
+const config = {
+  CONFIG: '.pos',
+  LEGACY_CONFIG: '.marketplace-kit'
+};
+
+const _paths = customConfig => [customConfig, config.CONFIG, config.LEGACY_CONFIG];
+
+const _getConfigPath = customConfig => {
+  const firstExistingConfig = _paths(customConfig).filter(fs.existsSync)[0];
+  logger.Debug(`[_getConfigPath] First existing config file: ${firstExistingConfig}`);
+  return path.resolve(firstExistingConfig || config.CONFIG);
+};
+
+const _readJSON = filePath => {
+  if (fs.existsSync(filePath)) {
+    logger.Debug(`[_readJSON] Found file at ${filePath}`);
+
+    var absPath = path.resolve(filePath);
+    return JSON.parse(fs.readFileSync(absPath, { encoding: 'utf8' }));
+  } else {
+    logger.Debug(`[_readJSON] Invalid JSON file at ${absPath}`);
+    return {};
+  }
+};
+
+const methods = {
+  readJSON: _readJSON,
+  getConfigPath: _getConfigPath,
+  getConfig: () => {
+    const configPath = _getConfigPath(process.env.CONFIG_FILE_PATH);
+    logger.Debug(`[getConfig] Looking for config in: ${configPath}`);
+    return _readJSON(configPath);
+  }
+};
+
+module.exports = Object.assign({}, config, methods);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,21 +1,12 @@
-const fs = require('fs'),
-  logger = require('./logger'),
+const logger = require('./logger'),
+  files = require('./files'),
   dir = require('./directories');
 
-const loadSettingsFile = path => {
-  if (fs.existsSync(path)) {
-    return JSON.parse(fs.readFileSync(path));
-  } else {
-    return {};
-  }
-};
-
-const loadSettingsFileForModule = module => loadSettingsFile(`${dir.MODULES}/${module}/template-values.json`);
-const existingSettings = () => loadSettingsFile(process.env.CONFIG_FILE_PATH);
+const loadSettingsFileForModule = module => files.readJSON(`${dir.MODULES}/${module}/template-values.json`);
 
 // TODO: Get rid off program. Just return false in here and show help wherever it was executed.
 const fetchSettings = (environment, program) => {
-  const settings = settingsFromEnv() || existingSettings()[environment];
+  const settings = settingsFromEnv() || files.getConfig()[environment];
   if (settings) return settings;
 
   if (environment) {
@@ -26,16 +17,15 @@ const fetchSettings = (environment, program) => {
   program.help();
 };
 
-// TODO: Destructure
 const settingsFromEnv = () => {
-  const env = process.env;
-  if (env.MPKIT_URL && env.MPKIT_TOKEN && env.MPKIT_EMAIL) {
-    return { url: env.MPKIT_URL, email: env.MPKIT_EMAIL, token: env.MPKIT_TOKEN };
+  const { MPKIT_URL: url, MPKIT_EMAIL: email, MPKIT_TOKEN: token } = process.env;
+  if (url && token && email) {
+    return { url, email, token };
   }
 };
 
 const listEnvironments = () => {
-  const settings = Object(existingSettings());
+  const settings = Object(files.getConfig());
   const list = Object.keys(settings);
 
   if (list.length) {
@@ -45,4 +35,4 @@ const listEnvironments = () => {
   }
 };
 
-module.exports = { fetchSettings, listEnvironments, loadSettingsFile, loadSettingsFileForModule };
+module.exports = { fetchSettings, listEnvironments, loadSettingsFileForModule };

--- a/test/lib/files.test.js
+++ b/test/lib/files.test.js
@@ -1,15 +1,15 @@
-const settings = require('./../../lib/settings');
+const files = require('../../lib/files');
 
 const configFileExample = 'test/fixtures/template-values.json';
 
 test('returns empty hash if there is a problem loading configuration file', () => {
-  const config = settings.loadSettingsFile('');
+  const config = files.readJSON('');
 
   expect(config).toEqual({});
 });
 
 test('parses values from configuration file', () => {
-  const config = settings.loadSettingsFile(configFileExample);
+  const config = files.readJSON(configFileExample);
 
   expect(config['aKey']).toEqual('aStringValue');
 });


### PR DESCRIPTION
This PR deprecates `.marketplace-kit` file in favor of `.pos`.

It looks for config in this order:
1. `CONFIG_FILE_PATH` env
2. `.pos`
3. `.marketplace-kit`

When adding new env it creates .pos.

It should work with all three variants, and if all files exist, it will respect the order above when adding new one.

QA steps:
* Adding & listing envs should work as usual
* Deploys should work
* Sync should work
* Listing modules & removing modules should work