### PR TITLE
Include header with domain name in all requests

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -11,6 +11,7 @@ class Gateway {
 
     const headers = {
       Authorization: `Token ${token}`,
+      InstanceDomain: url,
       'User-Agent': `marketplace-kit/${version}`,
       From: email
     };


### PR DESCRIPTION
We need this header to be present in all authenticated requests.