### PR TITLE
Logs: display empty messages

### DIFF
--- a/bin/pos-cli-logs.js
+++ b/bin/pos-cli-logs.js
@@ -63,9 +63,7 @@ program
     const stream = new LogStream(authData);
 
     stream.on('message', ({ created_at, error_type, message }) => {
-      if (!message) {
-        return;
-      }
+      if (message == null) message = '';
 
       const text = `[${created_at.replace('T', ' ')}] - ${error_type}: ${message.replace(/\n$/, '')}`;
       const options = { exit: false, hideTimestamp: true };


### PR DESCRIPTION
When I logged variable that was empty I didn't get any log entries, even with custom error type
```liquid
{% log product_id, type: "foo" %}
```