### PR TITLE
add ability to filter logs by log type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.1.20
+* Add filter to `pos-cli logs` that allows to display only given log type
+
 ## 4.1.19 5 December 2019
 * .zip files are now correctly synced
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ pos-cli logs <environment>
 
 From now on as long as your `logs` command is running, logs will aprear here. Errors will trigger system notification if your operating system is supporting them.
 
+You can filter logs by type using `--filter` argument.
+
+```
+pos-cli logs <environment> --filter type
+```
+
+Example:
+
+```
+pos-cli logs staging --filter debug
+```
+
 ### Listing environments
 
 If you forgot know what your environments are named or the url that is corresponding to any name, use:

--- a/bin/pos-cli-logs.js
+++ b/bin/pos-cli-logs.js
@@ -24,16 +24,19 @@ class LogStream extends EventEmitter {
   }
 
   fetchData() {
-    this.gateway.logs({lastId: storage.lastId}).then(response => {
+    this.gateway.logs({ lastId: storage.lastId }).then(response => {
       const logs = response && response.logs;
       if (!logs) {
         return false;
       }
 
       for (let k in logs) {
-        let row = logs[k];
+        const row = logs[k];
+        const filter = !!program.filter && program.filter.toLowerCase();
+        const errorType = row.error_type.toLowerCase();
 
-        if (!!program.filter && program.filter != row.error_type) continue;
+        if (filter !== errorType) continue;
+
         if (!storage.exists(row.id)) {
           storage.add(row);
           this.emit('message', row);
@@ -50,7 +53,7 @@ const storage = {
     storage.logs[item.id] = item;
     storage.lastId = item.id;
   },
-  exists: key => storage.logs.hasOwnProperty(key),
+  exists: key => storage.logs.hasOwnProperty(key)
 };
 
 const isError = msg => /error/.test(msg.error_type);
@@ -59,25 +62,22 @@ program
   .name('pos-cli logs')
   .arguments('[environment]', 'name of environment. Example: staging')
   .option('--interval <interval>', 'time to wait between updates in ms', 3000)
-  .option('--filter <log type>', 'display only logs of given type')
+  .option('--filter <log type>', 'display only logs of given type, example: error')
   .action(environment => {
     const authData = fetchAuthData(environment, program);
     const stream = new LogStream(authData);
 
-    stream.on('message', ({created_at, error_type, message}) => {
+    stream.on('message', ({ created_at, error_type, message }) => {
       if (message == null) message = '';
 
-      const text = `[${created_at.replace(
-        'T',
-        ' ',
-      )}] - ${error_type}: ${message.replace(/\n$/, '')}`;
-      const options = {exit: false, hideTimestamp: true};
+      const text = `[${created_at.replace('T', ' ')}] - ${error_type}: ${message.replace(/\n$/, '')}`;
+      const options = { exit: false, hideTimestamp: true };
 
       if (isError(message)) {
         notifier.notify({
           title: error_type,
           message: message.slice(0, 100),
-          icon: path.resolve(__dirname, '../lib/pos-logo.png'),
+          icon: path.resolve(__dirname, '../lib/pos-logo.png')
         });
 
         logger.Error(text, options);


### PR DESCRIPTION
Filter options for logs: 

```
payment-examples [payouts-rc●●] % pos-cli logs dev --filter DEBUG
[10:51:56] Starting live logging...
[2019-11-11 09:29:40.697Z] - DEBUG: TEST
[2019-11-11 09:29:40.703Z] - DEBUG: data
```

If you need to escape the chaos of all different types of logs left in the project.