### PR TITLE
Extension check audit in some directories

### DIFF
--- a/lib/audit.js
+++ b/lib/audit.js
@@ -5,9 +5,10 @@ const logger = require('../lib/logger');
 const tags = require('../lib/audit/tags'),
   filters = require('../lib/audit/filters'),
   detailed = require('../lib/audit/detailed'),
-  extensions = require('../lib/audit/extensions');
+  extensions = require('../lib/audit/extensions'),
+  duplicateFile = require('../lib/audit/duplicateFile');
 
-const auditors = [tags, filters, detailed, extensions];
+const auditors = [tags, filters, detailed, extensions, duplicateFile];
 
 const printReport = results => {
   if (!results) {

--- a/lib/audit.js
+++ b/lib/audit.js
@@ -7,6 +7,8 @@ const tags = require('../lib/audit/tags'),
   detailed = require('../lib/audit/detailed'),
   extensions = require('../lib/audit/extensions');
 
+const auditors = [tags, filters, detailed, extensions];
+
 const printReport = results => {
   if (!results) {
     return;
@@ -21,15 +23,10 @@ const printReport = results => {
 };
 
 const run = async () => {
-  return Promise.all([tags.audit(), filters.audit(), detailed.audit(), extensions.audit()]).then(([tags, filters, detailed, extensions]) => {
-    const offences = [...Object.keys(tags), ...Object.keys(filters), ...Object.keys(detailed), extensions].length;
-
+  return Promise.all(auditors.map(auditor => auditor.audit())).then(reports => {
+    const offences = reports.map(report => Object.keys(report)).length;
     logger.Warn(`[Audit] ${offences} rule${offences === 1 ? '' : 's'} detected issues.`, { hideTimestamp: true });
-
-    printReport(tags);
-    printReport(filters);
-    printReport(detailed);
-    printReport(extensions);
+    reports.forEach(printReport);
   });
 };
 

--- a/lib/audit.js
+++ b/lib/audit.js
@@ -4,7 +4,8 @@ const logger = require('../lib/logger');
 
 const tags = require('../lib/audit/tags'),
   filters = require('../lib/audit/filters'),
-  detailed = require('../lib/audit/detailed');
+  detailed = require('../lib/audit/detailed'),
+  extensions = require('../lib/audit/extensions');
 
 const printReport = results => {
   if (!results) {
@@ -20,14 +21,15 @@ const printReport = results => {
 };
 
 const run = async () => {
-  return Promise.all([tags.audit(), filters.audit(), detailed.audit()]).then(([tags, filters, detailed]) => {
-    const offences = [...Object.keys(tags), ...Object.keys(filters), ...Object.keys(detailed)].length;
+  return Promise.all([tags.audit(), filters.audit(), detailed.audit(), extensions.audit()]).then(([tags, filters, detailed, extensions]) => {
+    const offences = [...Object.keys(tags), ...Object.keys(filters), ...Object.keys(detailed), extensions].length;
 
     logger.Warn(`[Audit] ${offences} rule${offences === 1 ? '' : 's'} detected issues.`, { hideTimestamp: true });
 
     printReport(tags);
     printReport(filters);
     printReport(detailed);
+    printReport(extensions);
   });
 };
 

--- a/lib/audit/duplicateFile.js
+++ b/lib/audit/duplicateFile.js
@@ -7,7 +7,17 @@ module.exports = {
     audit: async () => {
         let results = {};
 
-        files = await glob('app/**/_*.liquid', { filesOnly: true });
+        let appPartials = [];
+        try {
+            appPartials = await glob('app/views/partials/**/_*.liquid');
+        } catch (err) { }
+
+        let modulePartials = [];
+        try {
+            modulePartials = await glob('modules/**/{private,public}/views/partials/**/_*.liquid');
+        } catch (err) { }
+
+        const files = [...appPartials, ...modulePartials];
         for (file of files) {
             let parts = file.split('/');
             let fileName = parts[parts.length - 1];

--- a/lib/audit/duplicateFile.js
+++ b/lib/audit/duplicateFile.js
@@ -1,0 +1,31 @@
+const glob = require('tiny-glob');
+const fs = require('fs')
+
+const underScorePrefix = /^_*/;
+
+module.exports = {
+    audit: async () => {
+        let results = {};
+
+        files = await glob('app/**/_*.liquid', { filesOnly: true });
+        for (file of files) {
+            let parts = file.split('/');
+            let fileName = parts[parts.length - 1];
+            parts[parts.length - 1] = fileName.replace(underScorePrefix, '', -1)
+            const fileWithoutUndescore = parts.join('/');
+
+            if (fs.existsSync(fileWithoutUndescore)) {
+                results = {
+                    ...results,
+                    [`Multiple file names with the same partial for ${fileName}`]: {
+                        files: [file, fileWithoutUndescore],
+                        message: `Multiple file names with the same partial path`
+                    }
+
+                }
+            }
+        }
+
+        return results;
+    }
+}

--- a/lib/audit/extensions.js
+++ b/lib/audit/extensions.js
@@ -1,28 +1,51 @@
 const glob = require('tiny-glob');
 
-const directoriesOnlyLiquid = [
-    'forms',
-    'form_configurations',
-    'authorization_policies',
-    'notifications'
+
+const rules = [
+    {
+        directories: [
+            'forms',
+            'form_configurations',
+            'authorization_policies',
+            'notifications'
+        ],
+        extension: '.liquid'
+    },
+    {
+        directories: [
+            'custom_model_types',
+            'custom_model_schemas',
+            'instance_profile_types',
+            'instance_profile_schemas'
+        ],
+        extension: '.yml'
+    }
 ]
 
 module.exports = {
     audit: async () => {
         let results = {};
 
-        for (let i in directoriesOnlyLiquid) {
-            const dir = directoriesOnlyLiquid[i];
-            const files = await glob(`app/${dir}/**`, {
-                filesOnly: true
-            });
+        for (let rule of rules) {
+            for (let dir of rule.directories) {
+                let files;
+                try {
+                    files = await glob(`app/${dir}/**`, {
+                        filesOnly: true
+                    });
+                } catch (err) {
+                    continue;
+                }
 
-            if (files.length > 0) {
-                results = {
-                    ...results,
-                    [`Only .liquid files should be in ${dir}`]: {
-                        files: files,
-                        message: `Only .liquid files should be in app/${dir}/`
+                files = files.filter(file => !file.match(`${rule.extension}$`));
+
+                if (files.length > 0) {
+                    results = {
+                        ...results,
+                        [`Only ${rule.extension} files should be in ${dir}`]: {
+                            files: files,
+                            message: `Only ${rule.extension} files should be in app/${dir}/`
+                        }
                     }
                 }
             }

--- a/lib/audit/extensions.js
+++ b/lib/audit/extensions.js
@@ -1,6 +1,5 @@
 const glob = require('tiny-glob');
 
-
 const rules = [
     {
         directories: [

--- a/lib/audit/extensions.js
+++ b/lib/audit/extensions.js
@@ -18,6 +18,10 @@ const rules = [
             'instance_profile_schemas'
         ],
         extension: '.yml'
+    },
+    {
+        directories: ['graphql', 'graph_queries'],
+        extension: '.graphql'
     }
 ]
 

--- a/lib/audit/extensions.js
+++ b/lib/audit/extensions.js
@@ -31,17 +31,17 @@ module.exports = {
 
         for (let rule of rules) {
             for (let dir of rule.directories) {
-                let files;
+                let appFiles = [];
                 try {
-                    files = await glob(`app/${dir}/**`, {
-                        filesOnly: true
-                    });
-                } catch (err) {
-                    continue;
-                }
+                    appFiles = await glob(`app/${dir}/**`, { filesOnly: true });
+                } catch (err) { }
 
-                files = files.filter(file => !file.match(`\\${rule.extension}$`));
+                let moduleFiles = [];
+                try {
+                    moduleFiles = await glob(`modules/${dir}/**`, { filesOnly: true });
+                } catch (err) { }
 
+                files = [...appFiles, ...moduleFiles].filter(file => !file.match(`\\${rule.extension}$`));
                 if (files.length > 0) {
                     results = {
                         ...results,

--- a/lib/audit/extensions.js
+++ b/lib/audit/extensions.js
@@ -37,7 +37,7 @@ module.exports = {
                     continue;
                 }
 
-                files = files.filter(file => !file.match(`${rule.extension}$`));
+                files = files.filter(file => !file.match(`\\${rule.extension}$`));
 
                 if (files.length > 0) {
                     results = {

--- a/lib/audit/extensions.js
+++ b/lib/audit/extensions.js
@@ -1,0 +1,33 @@
+const glob = require('tiny-glob');
+
+const directoriesOnlyLiquid = [
+    'forms',
+    'form_configurations',
+    'authorization_policies',
+    'notifications'
+]
+
+module.exports = {
+    audit: async () => {
+        let results = {};
+
+        for (let i in directoriesOnlyLiquid) {
+            const dir = directoriesOnlyLiquid[i];
+            const files = await glob(`app/${dir}/**`, {
+                filesOnly: true
+            });
+
+            if (files.length > 0) {
+                results = {
+                    ...results,
+                    [`Only .liquid files should be in ${dir}`]: {
+                        files: files,
+                        message: `Only .liquid files should be in app/${dir}/`
+                    }
+                }
+            }
+        }
+
+        return results;
+    }
+};


### PR DESCRIPTION
Only allow .liquid files in the following directories:
* forms
* form_configurations
* authorization_policies
* notifications

Only allow .yml files in the following directories:
* custom_model_types
* custom_model_schemas
* instance_profile_types
* instance_profile_schemas

Check for liquid files with the same partial paths.

Fixes #352.
Fixes #353.