### PR TITLE
Workaround incorrect tiny-glob globbing

### DIFF
--- a/lib/audit/detailed.js
+++ b/lib/audit/detailed.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const glob = require('tiny-glob');
 
+const { filterAppModules } = require('../directories');
+
 /*
   glob [string - glob]
     Try to be as specific as possible to make it fast.
@@ -63,10 +65,9 @@ module.exports = {
   audit: async () => {
     let results = {};
 
+
     for (let rule of detailed) {
-      const files = await glob(`{app,modules}/**/${rule.glob}`, {
-        filesOnly: true
-      });
+      const files = filterAppModules(await glob(`**/${rule.glob}`, { filesOnly: true }));
 
       for (let file of files) {
         const fileContents = fs.readFileSync(file, { encoding: 'utf8' });

--- a/lib/audit/filters.js
+++ b/lib/audit/filters.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const glob = require('tiny-glob');
 
+const { filterAppModules } = require('../directories');
+
 // TODO: Cleanup after old stack is dead
 const filters = [
   'active_class',
@@ -70,9 +72,7 @@ const _message = match => `[DEPRECATED FILTER] ${match}`;
 module.exports = {
   audit: async () => {
     let results = {};
-    const files = await glob('{app,modules}/**/*.liquid', {
-      filesOnly: true
-    });
+    const files = filterAppModules(await glob('**/*.liquid', { filesOnly: true }));
 
     for (let file of files) {
       const fileContents = fs.readFileSync(file, { encoding: 'utf8' });

--- a/lib/audit/tags.js
+++ b/lib/audit/tags.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const glob = require('tiny-glob');
 
+const { filterAppModules } = require('../directories');
+
 // TODO: Cleanup after old stack is dead
 const tags = [
   'cache_for',
@@ -40,10 +42,8 @@ const _message = match => `[DEPRECATED TAG] ${match}`;
 module.exports = {
   audit: async () => {
     let results = {};
-    const files = await glob('{app,modules}/**/*.liquid', {
-      filesOnly: true
-    });
 
+    const files = filterAppModules(await glob('**/*.liquid', { filesOnly: true }));
     for (let file of files) {
       const fileContents = fs.readFileSync(file, { encoding: 'utf8' });
       const matches = fileContents.match(test);

--- a/lib/directories.js
+++ b/lib/directories.js
@@ -20,4 +20,8 @@ const methods = {
   available: () => computed.ALLOWED.filter(fs.existsSync)
 };
 
-module.exports = Object.assign({}, app, internal, computed, methods);
+// Filter for {app,modules,marketplace_builder}/ top level directories.
+// This is necessary because tiny-glob doesn't return files from all subdirectories: https://github.com/terkelg/tiny-glob/issues/28
+const filterAppModules = files => files.filter(file => file.match(new RegExp(`^(${Object.values(app).join('|')})/`)));
+
+module.exports = { app, internal, computed, methods, filterAppModules };


### PR DESCRIPTION
Should fix the failing tests.

There is a bug in tiny-glob: https://github.com/terkelg/tiny-glob/issues/28
It's unresolved for a while, I think it opens up a discussion if we should replace it with an another globbing library.
I looked into if I can find where it's going wrong, but it's pretty easy to get lost in this code: https://github.com/terkelg/globrex/blob/master/index.js