### PR TITLE
Do not throw error when there is no status in waitForStatus

### DIFF
--- a/lib/data/waitForStatus.js
+++ b/lib/data/waitForStatus.js
@@ -1,14 +1,18 @@
+const logger = require('../logger');
+
 const waitForStatus = (statusCheck) => {
   return new Promise((resolve, reject) => {
     (getStatus = () => {
       statusCheck().then(response => {
-        if (response.status === 'pending' || response.status === 'ready_for_export') {
-          setTimeout(getStatus, 1500);
-        } else if (response.status === 'done' || response.status === 'success') {
-          resolve(response);
-        } else {
-          reject(response);
+        if (response.status) {
+          if (response.status === 'pending' || response.status === 'ready_for_export') {
+            setTimeout(getStatus, 1500);
+          } else if (response.status === 'done' || response.status === 'success') {
+            resolve(response);
+          }
         }
+      }).catch((error) => {
+        logger.Debug('[ERR] waitForStatus did not receive `status` in response object', error);
       });
     })();
   });


### PR DESCRIPTION
Reported by user:

```
TypeError: Cannot read property 'status' of undefined
    at /opt/homebrew/lib/node_modules/@platformos/pos-cli/lib/data/waitForStatus.js:5:22
    at tryCatcher (/opt/homebrew/lib/node_modules/@platformos/pos-cli/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/opt/homebrew/lib/node_modules/@platformos/pos-cli/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/opt/homebrew/lib/node_modules/@platformos/pos-cli/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromise0 (/opt/homebrew/lib/node_modules/@platformos/pos-cli/node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (/opt/homebrew/lib/node_modules/@platformos/pos-cli/node_modules/bluebird/js/release/promise.js:729:18)
    at _drainQueueStep (/opt/homebrew/lib/node_modules/@platformos/pos-cli/node_modules/bluebird/js/release/async.js:93:12)
    at _drainQueue (/opt/homebrew/lib/node_modules/@platformos/pos-cli/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/opt/homebrew/lib/node_modules/@platformos/pos-cli/node_modules/bluebird/js/release/async.js:102:5)
    at Immediate.Async.drainQueues [as _onImmediate] (/opt/homebrew/lib/node_modules/@platformos/pos-cli/node_modules/bluebird/js/release/async.js:15:14)
    at processImmediate (node:internal/timers:464:21)
```

This promise is too low level and should not be exposed to end user.