### PR TITLE
Avoid unhandled top level rejections which break sync

### DIFF
--- a/lib/ServerError.js
+++ b/lib/ServerError.js
@@ -48,8 +48,9 @@ const ServerError = {
   unprocessableEntity: request => {
     logger.Debug(`Unprocessable entity: ${JSON.stringify(request, null, 2)}`);
     const body = request.response.body;
-    if (body.error) {
-      const message = `${body.error}\n${(body.details && body.details.file_path) || ''}`;
+    const error = body.error || (body.errors && body.errors.join(', '));
+    if (error) {
+      const message = `${error}\n${(body.details && body.details.file_path) || ''}`;
       logger.Error(message, {
         hideTimestamp: true,
         exit: shouldExit(request)
@@ -68,7 +69,7 @@ const ServerError = {
 
   unauthorized: request => {
     logger.Debug(`Unauthorized: ${JSON.stringify(request, null, 2)}`);
-    logger.Error('You are unauthorized to do this operation. Check if your Token and URL is correct.', {
+    logger.Error('You are unauthorized to do this operation. Check if your Token/URL or email/password are correct.', {
       hideTimestamp: true,
       exit: shouldExit(request)
     });

--- a/lib/apiRequest.js
+++ b/lib/apiRequest.js
@@ -41,7 +41,6 @@ const apiRequest = ({ method = 'GET', uri, body, headers, formData, json = true,
         default:
           ServerError.default(request);
       }
-      throw request;
     })
     .catch(errors.RequestError, (reason) => {
       switch (reason.cause.code) {

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -37,11 +37,7 @@ const createVersion = async (token, accessUrl, moduleVersionName) => {
     const version = await portal.createVersion(token, accessUrl, moduleVersionName, moduleId)
     return version.id;
   } catch(e) {
-    let errorMessage;
-    if (e.statusCode === 422){
-      errorMessage = e.error.errors.join(', ');
-    }
-    throw new Error(`Module Version not created: ${errorMessage}`);
+    throw new Error(`Module Version not created`);
   }
 };
 
@@ -95,11 +91,6 @@ const portalAuthToken = async (email, password) => {
     const token = await portal.jwtToken(email, password)
     return token.auth_token;
   } catch (e) {
-    if (e.statusCode === 401) {
-      logger.Error('Either email or password is incorrect.');
-    } else {
-      logger.Error(e.message);
-    }
     process.exit(1);
   }
 };

--- a/test/modules-push.test.js
+++ b/test/modules-push.test.js
@@ -24,13 +24,14 @@ describe('Server errors', () => {
 
   test('Wrong email', async () => {
     const { stdout, stderr } = await run('good', '--email foo@example.com');
-    expect(stderr).toMatch('Either email or password is incorrect');
+    expect(stderr).toMatch('You are unauthorized to do this operation. Check if your Token/URL or email/password are correct.');
   });
 
   test('Wrong version', async () => {
     const { stdout, stderr } = await run('good', '--email pos-cli-ci@platformos.com');
     expect(stdout).toMatch("for access token");
     expect(stdout).toMatch("Release Uploaded");
-    expect(stderr).toMatch('Module Version not created: Name has already been taken');
+    expect(stderr).toMatch('Name has already been taken');
+    expect(stderr).toMatch('Module Version not created');
   });
 });


### PR DESCRIPTION
Any reason why this line was there and we're not treating these errors like the technical errors below? Alternatively I could add rejection handling code to various callers but first I wanted to explore this cleaner avenue.

This fix is to avoid unhandled top level rejections which break pos-cli and require a restart of pos-cli sync every time a few such errors occur (for example because of invalid syntax).

Thanks!