### PR TITLE
Fix for data export zip option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Feature: (LogsV2 Reports) Added a few built-in reports based on requests https://github.com/mdyd-dev/pos-cli/pull/572
 * Bug: (GUI) Fixed parsing `null` values on the database table view for `boolean` type
 * Improvement: (GUI) Editing `boolean` values not uses `<select>` instead of `textarea`
+* Bug: Fixed exporting as zip instead of JSON
 
 ## 4.17.1
 * Bug: (GUI) Fixed clearing `boolean` value saved as 'null' (string)

--- a/bin/pos-cli-data-export.js
+++ b/bin/pos-cli-data-export.js
@@ -47,7 +47,7 @@ program
     'use normal object `id` instead of `external_id` in exported json data',
     'false'
   )
-  .option('-z --zip', 'export to zip archive', 'false')
+  .option('-z --zip', 'export to zip archive', false)
   .action((environment, params) => {
     const isZipFile = params.zip;
     let filename = params.path;


### PR DESCRIPTION
Changed the default option from string 'false' to false, otherwise it always exports as zip.

Thanks!